### PR TITLE
Fix 70 recipes for Fabric version.

### DIFF
--- a/common/src/main/resources/data/dawnoftimebuilder/recipes/black_wrought_iron_fence.json
+++ b/common/src/main/resources/data/dawnoftimebuilder/recipes/black_wrought_iron_fence.json
@@ -10,7 +10,7 @@
 			"item": "dawnoftimebuilder:wrought_iron_fence"
 		},
 		"x": {
-			"tag": "forge:dyes/black"
+			"item": "minecraft:black_dye"
 		}
 	},
 	"result": {

--- a/common/src/main/resources/data/dawnoftimebuilder/recipes/candlestick.json
+++ b/common/src/main/resources/data/dawnoftimebuilder/recipes/candlestick.json
@@ -9,7 +9,7 @@
 			"item": "minecraft:candle"
 		},
 		"o": {
-			"tag": "forge:ingots/iron"
+			"item": "minecraft:iron_ingot"
 		}
 	},
 	"result": {

--- a/common/src/main/resources/data/dawnoftimebuilder/recipes/cast_iron_teacup_decorated.json
+++ b/common/src/main/resources/data/dawnoftimebuilder/recipes/cast_iron_teacup_decorated.json
@@ -6,10 +6,10 @@
 	],
 	"key": {
 		"I": {
-			"tag": "forge:ingots/iron"
+			"item": "minecraft:iron_ingot"
 		},
 		"i": {
-			"tag": "forge:ingots/gold"
+			"item": "minecraft:gold_ingot"
 		}
 	},
 	"result": {

--- a/common/src/main/resources/data/dawnoftimebuilder/recipes/cast_iron_teacup_gray.json
+++ b/common/src/main/resources/data/dawnoftimebuilder/recipes/cast_iron_teacup_gray.json
@@ -6,10 +6,10 @@
 	],
 	"key": {
 		"I": {
-			"tag": "forge:ingots/iron"
+			"item": "minecraft:iron_ingot"
 		},
 		"i": {
-			"tag": "forge:dyes/gray"
+			"item": "minecraft:gray_dye"
 		}
 	},
 	"result": {

--- a/common/src/main/resources/data/dawnoftimebuilder/recipes/cast_iron_teacup_green.json
+++ b/common/src/main/resources/data/dawnoftimebuilder/recipes/cast_iron_teacup_green.json
@@ -6,10 +6,10 @@
 	],
 	"key": {
 		"I": {
-			"tag": "forge:ingots/iron"
+			"item": "minecraft:iron_ingot"
 		},
 		"i": {
-			"tag": "forge:dyes/green"
+			"item": "minecraft:green_dye"
 		}
 	},
 	"result": {

--- a/common/src/main/resources/data/dawnoftimebuilder/recipes/cast_iron_teapot_decorated.json
+++ b/common/src/main/resources/data/dawnoftimebuilder/recipes/cast_iron_teapot_decorated.json
@@ -7,10 +7,10 @@
 	],
 	"key": {
 		"I": {
-			"tag": "forge:ingots/iron"
+			"item": "minecraft:iron_ingot"
 		},
 		"i": {
-			"tag": "forge:ingots/gold"
+			"item": "minecraft:gold_ingot"
 		}
 	},
 	"result": {

--- a/common/src/main/resources/data/dawnoftimebuilder/recipes/cast_iron_teapot_gray.json
+++ b/common/src/main/resources/data/dawnoftimebuilder/recipes/cast_iron_teapot_gray.json
@@ -7,10 +7,10 @@
 	],
 	"key": {
 		"I": {
-			"tag": "forge:ingots/iron"
+			"item": "minecraft:iron_ingot"
 		},
 		"i": {
-			"tag": "forge:dyes/gray"
+			"item": "minecraft:gray_dye"
 		}
 	},
 	"result": {

--- a/common/src/main/resources/data/dawnoftimebuilder/recipes/cast_iron_teapot_green.json
+++ b/common/src/main/resources/data/dawnoftimebuilder/recipes/cast_iron_teapot_green.json
@@ -7,10 +7,10 @@
 	],
 	"key": {
 		"I": {
-			"tag": "forge:ingots/iron"
+			"item": "minecraft:iron_ingot"
 		},
 		"i": {
-			"tag": "forge:dyes/green"
+			"item": "minecraft:green_dye"
 		}
 	},
 	"result": {

--- a/common/src/main/resources/data/dawnoftimebuilder/recipes/charred_spruce_boards.json
+++ b/common/src/main/resources/data/dawnoftimebuilder/recipes/charred_spruce_boards.json
@@ -10,7 +10,7 @@
 			"item": "dawnoftimebuilder:charred_spruce_planks"
 		},
 		"i": {
-			"tag": "forge:rods/wooden"
+			"item": "minecraft:stick"
 		}
 	},
 	"result": {

--- a/common/src/main/resources/data/dawnoftimebuilder/recipes/charred_spruce_door.json
+++ b/common/src/main/resources/data/dawnoftimebuilder/recipes/charred_spruce_door.json
@@ -10,7 +10,7 @@
 			"item": "dawnoftimebuilder:charred_spruce_planks"
 		},
 		"i": {
-			"tag": "forge:ingots/iron"
+			"item": "minecraft:iron_ingot"
 		}
 	},
 	"result": {

--- a/common/src/main/resources/data/dawnoftimebuilder/recipes/charred_spruce_fancy_railing.json
+++ b/common/src/main/resources/data/dawnoftimebuilder/recipes/charred_spruce_fancy_railing.json
@@ -9,7 +9,7 @@
 			"item": "dawnoftimebuilder:charred_spruce_log_stripped"
 		},
 		"i": {
-			"tag": "forge:rods/wooden"
+			"item": "minecraft:stick"
 		}
 	},
 	"result": {

--- a/common/src/main/resources/data/dawnoftimebuilder/recipes/charred_spruce_fence.json
+++ b/common/src/main/resources/data/dawnoftimebuilder/recipes/charred_spruce_fence.json
@@ -9,7 +9,7 @@
 			"item": "dawnoftimebuilder:charred_spruce_planks"
 		},
 		"i": {
-			"tag": "forge:rods/wooden"
+			"item": "minecraft:stick"
 		}
 	},
 	"result": {

--- a/common/src/main/resources/data/dawnoftimebuilder/recipes/charred_spruce_fence_gate.json
+++ b/common/src/main/resources/data/dawnoftimebuilder/recipes/charred_spruce_fence_gate.json
@@ -7,7 +7,7 @@
   ],
   "key": {
     "#": {
-      "tag": "forge:rods/wooden"
+      "item": "minecraft:stick"
     },
     "W": {
       "item": "dawnoftimebuilder:charred_spruce_planks"

--- a/common/src/main/resources/data/dawnoftimebuilder/recipes/charred_spruce_foundation.json
+++ b/common/src/main/resources/data/dawnoftimebuilder/recipes/charred_spruce_foundation.json
@@ -10,7 +10,7 @@
 			"item": "dawnoftimebuilder:charred_spruce_planks"
 		},
 		"i": {
-			"tag": "forge:rods/wooden"
+			"item": "minecraft:stick"
 		}
 	},
 	"result": {

--- a/common/src/main/resources/data/dawnoftimebuilder/recipes/charred_spruce_railing.json
+++ b/common/src/main/resources/data/dawnoftimebuilder/recipes/charred_spruce_railing.json
@@ -9,7 +9,7 @@
 			"item": "dawnoftimebuilder:charred_spruce_log_stripped"
 		},
 		"i": {
-			"tag": "forge:rods/wooden"
+			"item": "minecraft:stick"
 		}
 	},
 	"result": {

--- a/common/src/main/resources/data/dawnoftimebuilder/recipes/charred_spruce_shutters.json
+++ b/common/src/main/resources/data/dawnoftimebuilder/recipes/charred_spruce_shutters.json
@@ -9,7 +9,7 @@
 			"item": "dawnoftimebuilder:charred_spruce_planks"
 		},
 		"i": {
-			"tag": "forge:ingots/iron"
+			"item": "minecraft:iron_ingot"
 		}
 	},
 	"result": {

--- a/common/src/main/resources/data/dawnoftimebuilder/recipes/charred_spruce_tall_shutters.json
+++ b/common/src/main/resources/data/dawnoftimebuilder/recipes/charred_spruce_tall_shutters.json
@@ -10,7 +10,7 @@
 			"item": "dawnoftimebuilder:charred_spruce_planks"
 		},
 		"i": {
-			"tag": "forge:ingots/iron"
+			"item": "minecraft:iron_ingot"
 		}
 	},
 	"result": {

--- a/common/src/main/resources/data/dawnoftimebuilder/recipes/clay_tile_black.json
+++ b/common/src/main/resources/data/dawnoftimebuilder/recipes/clay_tile_black.json
@@ -26,7 +26,7 @@
 			"item": "dawnoftimebuilder:clay_tile"
 		},
 		{
-			"tag": "forge:dyes/black"
+			"item": "minecraft:black_dye"
 		}
 	],
 	"result": {

--- a/common/src/main/resources/data/dawnoftimebuilder/recipes/clay_tile_blue.json
+++ b/common/src/main/resources/data/dawnoftimebuilder/recipes/clay_tile_blue.json
@@ -26,7 +26,7 @@
 			"item": "dawnoftimebuilder:clay_tile"
 		},
 		{
-			"tag": "forge:dyes/blue"
+			"item": "minecraft:blue_dye"
 		}
 	],
 	"result": {

--- a/common/src/main/resources/data/dawnoftimebuilder/recipes/clay_tile_cyan.json
+++ b/common/src/main/resources/data/dawnoftimebuilder/recipes/clay_tile_cyan.json
@@ -26,7 +26,7 @@
 			"item": "dawnoftimebuilder:clay_tile"
 		},
 		{
-			"tag": "forge:dyes/cyan"
+			"item": "minecraft:cyan_dye"
 		}
 	],
 	"result": {

--- a/common/src/main/resources/data/dawnoftimebuilder/recipes/clay_tile_orange.json
+++ b/common/src/main/resources/data/dawnoftimebuilder/recipes/clay_tile_orange.json
@@ -26,7 +26,7 @@
 			"item": "dawnoftimebuilder:clay_tile"
 		},
 		{
-			"tag": "forge:dyes/orange"
+			"item": "minecraft:orange_dye"
 		}
 	],
 	"result": {

--- a/common/src/main/resources/data/dawnoftimebuilder/recipes/clay_tile_white.json
+++ b/common/src/main/resources/data/dawnoftimebuilder/recipes/clay_tile_white.json
@@ -26,7 +26,7 @@
 			"item": "dawnoftimebuilder:clay_tile"
 		},
 		{
-			"tag": "forge:dyes/white"
+			"item": "minecraft:white_dye"
 		}
 	],
 	"result": {

--- a/common/src/main/resources/data/dawnoftimebuilder/recipes/feathered_serpent_sculpture.json
+++ b/common/src/main/resources/data/dawnoftimebuilder/recipes/feathered_serpent_sculpture.json
@@ -9,10 +9,10 @@
 			"item": "minecraft:stone"
 		},
 		"i": {
-			"tag": "forge:dyes/green"
+			"item": "minecraft:green_dye"
 		},
 		"o": {
-			"tag": "forge:nuggets/gold"
+			"item": "minecraft:gold_nugget"
 		}
 	},
 	"result": {

--- a/common/src/main/resources/data/dawnoftimebuilder/recipes/fireplace.json
+++ b/common/src/main/resources/data/dawnoftimebuilder/recipes/fireplace.json
@@ -12,7 +12,7 @@
 			"tag": "minecraft:coals"
 		},
 		"o": {
-			"tag": "forge:nuggets/iron"
+			"item": "minecraft:iron_nugget"
 		}
 	},
 	"result": {

--- a/common/src/main/resources/data/dawnoftimebuilder/recipes/gold_plated_smooth_block.json
+++ b/common/src/main/resources/data/dawnoftimebuilder/recipes/gold_plated_smooth_block.json
@@ -8,17 +8,17 @@
 	"key": {
 		"x": [
 			{
-				"tag": "forge:sandstone"
+				"item": "minecraft:sandstone"
 			},
 			{
-				"tag": "forge:stone"
+				"item": "minecraft:stone"
 			},
 			{
-				"tag": "forge:cobblestone"
+				"item": "minecraft:cobblestone"
 			}
 		],
 		"o":{
-			"tag": "forge:nuggets/gold"
+			"item": "minecraft:gold_nugget"
 		}
 	},
 	"result": {

--- a/common/src/main/resources/data/dawnoftimebuilder/recipes/green__ornamented_chiseled_plastered_stone.json
+++ b/common/src/main/resources/data/dawnoftimebuilder/recipes/green__ornamented_chiseled_plastered_stone.json
@@ -10,10 +10,10 @@
 			"item": "dawnoftimebuilder:plastered_stone"
 		},
 		"i": {
-			"tag": "forge:dyes/green"
+			"item": "minecraft:green_dye"
 		},
 		"o": {
-			"tag": "forge:nuggets/gold"
+			"item": "minecraft:gold_nugget"
 		}
 	},
 	"result": {

--- a/common/src/main/resources/data/dawnoftimebuilder/recipes/green_chiseled_plastered_stone.json
+++ b/common/src/main/resources/data/dawnoftimebuilder/recipes/green_chiseled_plastered_stone.json
@@ -10,7 +10,7 @@
 			"item": "dawnoftimebuilder:plastered_stone"
 		},
 		"i": {
-			"tag": "forge:dyes/green"
+			"item": "minecraft:green_dye"
 		}
 	},
 	"result": {

--- a/common/src/main/resources/data/dawnoftimebuilder/recipes/green_ornamented_plastered_stone_frieze.json
+++ b/common/src/main/resources/data/dawnoftimebuilder/recipes/green_ornamented_plastered_stone_frieze.json
@@ -9,10 +9,10 @@
 			"item": "dawnoftimebuilder:plastered_stone"
 		},
 		"o": {
-			"tag": "forge:nuggets/gold"
+			"item": "minecraft:gold_nugget"
 		},
 		"i": {
-			"tag": "forge:dyes/green"
+			"item": "minecraft:green_dye"
 		}
 	},
 	"result": {

--- a/common/src/main/resources/data/dawnoftimebuilder/recipes/green_plastered_stone_frieze.json
+++ b/common/src/main/resources/data/dawnoftimebuilder/recipes/green_plastered_stone_frieze.json
@@ -10,7 +10,7 @@
 			"item": "dawnoftimebuilder:plastered_stone"
 		},
 		"i": {
-			"tag": "forge:dyes/green"
+			"item": "minecraft:green_dye"
 		}
 	},
 	"result": {

--- a/common/src/main/resources/data/dawnoftimebuilder/recipes/green_sculpted_plastered_stone_frieze.json
+++ b/common/src/main/resources/data/dawnoftimebuilder/recipes/green_sculpted_plastered_stone_frieze.json
@@ -10,10 +10,10 @@
 			"item": "dawnoftimebuilder:plastered_stone"
 		},
 		"i": {
-			"tag": "forge:dyes/green"
+			"item": "minecraft:green_dye"
 		},
 		"o": {
-			"tag": "forge:nuggets/gold"
+			"item": "minecraft:gold_nugget"
 		}
 	},
 	"result": {

--- a/common/src/main/resources/data/dawnoftimebuilder/recipes/green_small_plastered_stone_frieze.json
+++ b/common/src/main/resources/data/dawnoftimebuilder/recipes/green_small_plastered_stone_frieze.json
@@ -8,7 +8,7 @@
 			"item": "dawnoftimebuilder:plastered_stone"
 		},
 		"i": {
-			"tag": "forge:dyes/green"
+			"item": "minecraft:green_dye"
 		}
 	},
 	"result": {

--- a/common/src/main/resources/data/dawnoftimebuilder/recipes/iron_column.json
+++ b/common/src/main/resources/data/dawnoftimebuilder/recipes/iron_column.json
@@ -7,7 +7,7 @@
 	],
 	"key": {
 		"o": {
-			"tag": "forge:ingots/iron"
+			"item": "minecraft:iron_ingot"
 		}
 	},
 	"result": {

--- a/common/src/main/resources/data/dawnoftimebuilder/recipes/iron_fancy_lantern.json
+++ b/common/src/main/resources/data/dawnoftimebuilder/recipes/iron_fancy_lantern.json
@@ -7,13 +7,13 @@
 	],
 	"key": {
 		"I": {
-			"tag": "forge:ingots/iron"
+			"item": "minecraft:iron_ingot"
 		},
 		"x": {
 			"item": "minecraft:torch"
 		},
 		"o": {
-			"tag": "forge:nuggets/iron"
+			"item": "minecraft:iron_nugget"
 		}
 	},
 	"result": {

--- a/common/src/main/resources/data/dawnoftimebuilder/recipes/iron_portcullis.json
+++ b/common/src/main/resources/data/dawnoftimebuilder/recipes/iron_portcullis.json
@@ -7,7 +7,7 @@
 	],
 	"key": {
 		"I": {
-			"tag": "forge:ingots/iron"
+			"item": "minecraft:iron_ingot"
 		}
 	},
 	"result": {

--- a/common/src/main/resources/data/dawnoftimebuilder/recipes/irori_fireplace.json
+++ b/common/src/main/resources/data/dawnoftimebuilder/recipes/irori_fireplace.json
@@ -12,7 +12,7 @@
 			"item": "minecraft:spruce_log"
 		},
 		"o": {
-			"tag": "forge:ingots/iron"
+			"item": "minecraft:iron_ingot"
 		}
 	},
 	"result": {

--- a/common/src/main/resources/data/dawnoftimebuilder/recipes/ochre_roof_tiles.json
+++ b/common/src/main/resources/data/dawnoftimebuilder/recipes/ochre_roof_tiles.json
@@ -9,7 +9,7 @@
 			"item": "minecraft:stone"
 		},
 		"i": {
-			"tag": "forge:dyes/orange"
+			"item": "minecraft:orange_dye"
 		}
 	},
 	"result": {

--- a/common/src/main/resources/data/dawnoftimebuilder/recipes/ornamented_chiseled_plastered_stone.json
+++ b/common/src/main/resources/data/dawnoftimebuilder/recipes/ornamented_chiseled_plastered_stone.json
@@ -10,7 +10,7 @@
 			"item": "dawnoftimebuilder:plastered_stone"
 		},
 		"i": {
-			"tag": "forge:nuggets/gold"
+			"item": "minecraft:gold_nugget"
 		}
 	},
 	"result": {

--- a/common/src/main/resources/data/dawnoftimebuilder/recipes/paper_door.json
+++ b/common/src/main/resources/data/dawnoftimebuilder/recipes/paper_door.json
@@ -7,7 +7,7 @@
 	],
 	"key": {
 		"i": {
-			"tag": "forge:rods/wooden"
+			"item": "minecraft:stick"
 		},
 		"I": {
 			"item": "minecraft:paper"

--- a/common/src/main/resources/data/dawnoftimebuilder/recipes/paper_folding_screen.json
+++ b/common/src/main/resources/data/dawnoftimebuilder/recipes/paper_folding_screen.json
@@ -10,7 +10,7 @@
 			"item": "minecraft:paper"
 		},
 		"I": {
-			"tag": "forge:rods/wooden"
+			"item": "minecraft:stick"
 		},
 		"o": {
 			"item": "minecraft:ink_sac"

--- a/common/src/main/resources/data/dawnoftimebuilder/recipes/paper_lamp.json
+++ b/common/src/main/resources/data/dawnoftimebuilder/recipes/paper_lamp.json
@@ -7,7 +7,7 @@
 	],
 	"key": {
 		"o": {
-			"tag": "forge:rods/wooden"
+			"item": "minecraft:stick"
 		},
 		"O": {
 			"item": "minecraft:torch"

--- a/common/src/main/resources/data/dawnoftimebuilder/recipes/paper_wall.json
+++ b/common/src/main/resources/data/dawnoftimebuilder/recipes/paper_wall.json
@@ -10,7 +10,7 @@
 			"item": "minecraft:paper"
 		},
 		"i": {
-			"tag": "forge:rods/wooden"
+			"item": "minecraft:stick"
 		}
 	},
 	"result": {

--- a/common/src/main/resources/data/dawnoftimebuilder/recipes/paper_wall_flat.json
+++ b/common/src/main/resources/data/dawnoftimebuilder/recipes/paper_wall_flat.json
@@ -10,7 +10,7 @@
 			"item": "minecraft:paper"
 		},
 		"I": {
-			"tag": "forge:rods/wooden"
+			"item": "minecraft:stick"
 		}
 	},
 	"result": {

--- a/common/src/main/resources/data/dawnoftimebuilder/recipes/paper_wall_window.json
+++ b/common/src/main/resources/data/dawnoftimebuilder/recipes/paper_wall_window.json
@@ -7,7 +7,7 @@
 	],
 	"key": {
 		"I": {
-			"tag": "forge:rods/wooden"
+			"item": "minecraft:stick"
 		},
 		"i": {
 			"item": "minecraft:paper"

--- a/common/src/main/resources/data/dawnoftimebuilder/recipes/plastered_stone_cresset.json
+++ b/common/src/main/resources/data/dawnoftimebuilder/recipes/plastered_stone_cresset.json
@@ -10,7 +10,7 @@
 			"item": "dawnoftimebuilder:plastered_stone"
 		},
 		"i": {
-			"tag": "forge:nuggets/gold"
+			"item": "minecraft:gold_nugget"
 		},
 		"x": {
 			"item": "minecraft:coal"

--- a/common/src/main/resources/data/dawnoftimebuilder/recipes/red_chiseled_plastered_stone.json
+++ b/common/src/main/resources/data/dawnoftimebuilder/recipes/red_chiseled_plastered_stone.json
@@ -10,7 +10,7 @@
 			"item": "dawnoftimebuilder:plastered_stone"
 		},
 		"i": {
-			"tag": "forge:dyes/red"
+			"item": "minecraft:red_dye"
 		}
 	},
 	"result": {

--- a/common/src/main/resources/data/dawnoftimebuilder/recipes/red_ornamented_chiseled_platered_stone.json
+++ b/common/src/main/resources/data/dawnoftimebuilder/recipes/red_ornamented_chiseled_platered_stone.json
@@ -10,10 +10,10 @@
 			"item": "dawnoftimebuilder:plastered_stone"
 		},
 		"i": {
-			"tag": "forge:nuggets/gold"
+			"item": "minecraft:gold_nugget"
 		},
 		"o": {
-			"tag": "forge:dyes/red"
+			"item": "minecraft:red_dye"
 		}
 	},
 	"result": {

--- a/common/src/main/resources/data/dawnoftimebuilder/recipes/red_ornamented_plastered_stone_frieze.json
+++ b/common/src/main/resources/data/dawnoftimebuilder/recipes/red_ornamented_plastered_stone_frieze.json
@@ -9,10 +9,10 @@
 			"item": "dawnoftimebuilder:plastered_stone"
 		},
 		"o": {
-			"tag": "forge:nuggets/gold"
+			"item": "minecraft:gold_nugget"
 		},
 		"i": {
-			"tag": "forge:dyes/red"
+			"item": "minecraft:red_dye"
 		}
 	},
 	"result": {

--- a/common/src/main/resources/data/dawnoftimebuilder/recipes/red_ornamented_platered_stone.json
+++ b/common/src/main/resources/data/dawnoftimebuilder/recipes/red_ornamented_platered_stone.json
@@ -10,7 +10,7 @@
 			"item": "dawnoftimebuilder:red_plastered_stone"
 		},
 		"i": {
-			"tag": "forge:nuggets/gold"
+			"item": "minecraft:gold_nugget"
 		}
 	},
 	"result": {

--- a/common/src/main/resources/data/dawnoftimebuilder/recipes/red_painted_beam.json
+++ b/common/src/main/resources/data/dawnoftimebuilder/recipes/red_painted_beam.json
@@ -2,7 +2,7 @@
 	"type": "minecraft:crafting_shapeless",
 	"ingredients": [
 		{
-			"tag": "forge:dyes/red"
+			"item": "minecraft:red_dye"
 		},
 		{
 			"item": "minecraft:spruce_log"

--- a/common/src/main/resources/data/dawnoftimebuilder/recipes/red_paper_lantern.json
+++ b/common/src/main/resources/data/dawnoftimebuilder/recipes/red_paper_lantern.json
@@ -7,7 +7,7 @@
 	],
 	"key": {
 		"i": {
-			"tag": "forge:rods/wooden"
+			"item": "minecraft:stick"
 		},
 		"O": {
 			"item": "minecraft:torch"

--- a/common/src/main/resources/data/dawnoftimebuilder/recipes/red_plastered_stone.json
+++ b/common/src/main/resources/data/dawnoftimebuilder/recipes/red_plastered_stone.json
@@ -9,7 +9,7 @@
 			"item": "minecraft:stone"
 		},
 		"i": {
-			"tag": "forge:dyes/red"
+			"item": "minecraft:red_dye"
 		}
 	},
 	"result": {

--- a/common/src/main/resources/data/dawnoftimebuilder/recipes/red_plastered_stone_frieze.json
+++ b/common/src/main/resources/data/dawnoftimebuilder/recipes/red_plastered_stone_frieze.json
@@ -10,7 +10,7 @@
 			"item": "dawnoftimebuilder:plastered_stone"
 		},
 		"i": {
-			"tag": "forge:dyes/red"
+			"item": "minecraft:red_dye"
 		}
 	},
 	"result": {

--- a/common/src/main/resources/data/dawnoftimebuilder/recipes/red_sculpted_plastered_stone_frieze.json
+++ b/common/src/main/resources/data/dawnoftimebuilder/recipes/red_sculpted_plastered_stone_frieze.json
@@ -10,10 +10,10 @@
 			"item": "dawnoftimebuilder:plastered_stone"
 		},
 		"i": {
-			"tag": "forge:dyes/red"
+			"item": "minecraft:red_dye"
 		},
 		"o": {
-			"tag": "forge:nuggets/gold"
+			"item": "minecraft:gold_nugget"
 		}
 	},
 	"result": {

--- a/common/src/main/resources/data/dawnoftimebuilder/recipes/red_small_plastered_stone_frieze.json
+++ b/common/src/main/resources/data/dawnoftimebuilder/recipes/red_small_plastered_stone_frieze.json
@@ -8,7 +8,7 @@
 			"item": "dawnoftimebuilder:plastered_stone"
 		},
 		"i": {
-			"tag": "forge:dyes/red"
+			"item": "minecraft:red_dye"
 		}
 	},
 	"result": {

--- a/common/src/main/resources/data/dawnoftimebuilder/recipes/reinforced_golden_wrought_iron_fence.json
+++ b/common/src/main/resources/data/dawnoftimebuilder/recipes/reinforced_golden_wrought_iron_fence.json
@@ -2,7 +2,7 @@
 	"type": "minecraft:crafting_shapeless",
 	"ingredients": [
 		{
-			"tag": "forge:nuggets/gold"
+			"item": "minecraft:gold_nugget"
 		},
 		{
 			"item": "dawnoftimebuilder:reinforced_black_wrought_iron_fence"

--- a/common/src/main/resources/data/dawnoftimebuilder/recipes/roman_fresco_black.json
+++ b/common/src/main/resources/data/dawnoftimebuilder/recipes/roman_fresco_black.json
@@ -10,7 +10,7 @@
 			"item": "minecraft:sandstone"
 		},
 		"x": {
-			"tag": "forge:dyes/black"
+			"item": "minecraft:black_dye"
 		}
 	},
 	"result": {

--- a/common/src/main/resources/data/dawnoftimebuilder/recipes/roman_fresco_red.json
+++ b/common/src/main/resources/data/dawnoftimebuilder/recipes/roman_fresco_red.json
@@ -10,7 +10,7 @@
 			"item": "minecraft:sandstone"
 		},
 		"x": {
-			"tag": "forge:dyes/red"
+			"item": "minecraft:red_dye"
 		}
 	},
 	"result": {

--- a/common/src/main/resources/data/dawnoftimebuilder/recipes/serpent_sculpted_column.json
+++ b/common/src/main/resources/data/dawnoftimebuilder/recipes/serpent_sculpted_column.json
@@ -10,10 +10,10 @@
 			"item": "minecraft:stone"
 		},
 		"i": {
-			"tag": "forge:dyes/green"
+			"item": "minecraft:green_dye"
 		},
 		"o": {
-			"tag": "forge:nuggets/gold"
+			"item": "minecraft:gold_nugget"
 		}
 	},
 	"result": {

--- a/common/src/main/resources/data/dawnoftimebuilder/recipes/spruce_low_table.json
+++ b/common/src/main/resources/data/dawnoftimebuilder/recipes/spruce_low_table.json
@@ -9,7 +9,7 @@
 			"item": "minecraft:spruce_slab"
 		},
 		"i": {
-			"tag": "forge:rods/wooden"
+			"item": "minecraft:stick"
 		}
 	},
 	"result": {

--- a/common/src/main/resources/data/dawnoftimebuilder/recipes/stick_bundle.json
+++ b/common/src/main/resources/data/dawnoftimebuilder/recipes/stick_bundle.json
@@ -7,7 +7,7 @@
 	],
 	"key": {
 		"i": {
-			"tag": "forge:rods/wooden"
+			"item": "minecraft:stick"
 		},
 		"I": {
 			"item": "minecraft:string"

--- a/common/src/main/resources/data/dawnoftimebuilder/recipes/stone_bricks_faucet.json
+++ b/common/src/main/resources/data/dawnoftimebuilder/recipes/stone_bricks_faucet.json
@@ -12,10 +12,10 @@
 			"item": "minecraft:water_bucket"
 		},
 		"I": {
-			"tag": "forge:nuggets/iron"
+			"item": "minecraft:iron_nugget"
 		},
 		"u": {
-			"tag": "forge:dusts/redstone"
+			"item": "minecraft:redstone"
 		}
 	},
 	"result": {

--- a/common/src/main/resources/data/dawnoftimebuilder/recipes/stone_bricks_water_jet.json
+++ b/common/src/main/resources/data/dawnoftimebuilder/recipes/stone_bricks_water_jet.json
@@ -12,10 +12,10 @@
 			"item": "minecraft:water_bucket"
 		},
 		"I": {
-			"tag": "forge:nuggets/iron"
+			"item": "minecraft:iron_nugget"
 		},
 		"u": {
-			"tag": "forge:dusts/redstone"
+			"item": "minecraft:redstone"
 		}
 	},
 	"result": {

--- a/common/src/main/resources/data/dawnoftimebuilder/recipes/waxed_oak_chair.json
+++ b/common/src/main/resources/data/dawnoftimebuilder/recipes/waxed_oak_chair.json
@@ -13,7 +13,7 @@
 			"item": "dawnoftimebuilder:thatch_wheat"
 		},
 		"i": {
-			"tag": "forge:rods/wooden"
+			"item": "minecraft:stick"
 		}
 	},
 	"result": {

--- a/common/src/main/resources/data/dawnoftimebuilder/recipes/waxed_oak_door.json
+++ b/common/src/main/resources/data/dawnoftimebuilder/recipes/waxed_oak_door.json
@@ -7,7 +7,7 @@
 	],
 	"key": {
 		"I": {
-			"tag": "forge:ingots/iron"
+			"item": "minecraft:iron_ingot"
 		},
 		"i": {
 			"item": "dawnoftimebuilder:waxed_oak_planks"

--- a/common/src/main/resources/data/dawnoftimebuilder/recipes/waxed_oak_fence.json
+++ b/common/src/main/resources/data/dawnoftimebuilder/recipes/waxed_oak_fence.json
@@ -9,7 +9,7 @@
 			"item": "dawnoftimebuilder:waxed_oak_planks"
 		},
 		"i": {
-			"tag": "forge:rods/wooden"
+			"item": "minecraft:stick"
 		}
 	},
 	"result": {

--- a/common/src/main/resources/data/dawnoftimebuilder/recipes/waxed_oak_fence_gate.json
+++ b/common/src/main/resources/data/dawnoftimebuilder/recipes/waxed_oak_fence_gate.json
@@ -7,7 +7,7 @@
   ],
   "key": {
     "#": {
-      "tag": "forge:rods/wooden"
+      "item": "minecraft:stick"
     },
     "W": {
       "item": "dawnoftimebuilder:waxed_oak_planks"

--- a/common/src/main/resources/data/dawnoftimebuilder/recipes/waxed_oak_shutters.json
+++ b/common/src/main/resources/data/dawnoftimebuilder/recipes/waxed_oak_shutters.json
@@ -10,7 +10,7 @@
 			"item": "dawnoftimebuilder:waxed_oak_planks"
 		},
 		"i": {
-			"tag": "forge:rods/wooden"
+			"item": "minecraft:stick"
 		}
 	},
 	"result": {

--- a/common/src/main/resources/data/dawnoftimebuilder/recipes/waxed_oak_small_shutters.json
+++ b/common/src/main/resources/data/dawnoftimebuilder/recipes/waxed_oak_small_shutters.json
@@ -9,7 +9,7 @@
 			"item": "dawnoftimebuilder:waxed_oak_planks"
 		},
 		"i": {
-			"tag": "forge:rods/wooden"
+			"item": "minecraft:stick"
 		}
 	},
 	"result": {

--- a/common/src/main/resources/data/dawnoftimebuilder/recipes/waxed_oak_table.json
+++ b/common/src/main/resources/data/dawnoftimebuilder/recipes/waxed_oak_table.json
@@ -10,7 +10,7 @@
 			"item": "dawnoftimebuilder:waxed_oak_planks_slab"
 		},
 		"i": {
-			"tag": "forge:rods/wooden"
+			"item": "minecraft:stick"
 		}
 	},
 	"result": {

--- a/common/src/main/resources/data/dawnoftimebuilder/recipes/white_little_flag.json
+++ b/common/src/main/resources/data/dawnoftimebuilder/recipes/white_little_flag.json
@@ -9,7 +9,7 @@
 			"item": "dawnoftimebuilder:silk"
 		},
 		"i": {
-			"tag": "forge:rods/wooden"
+			"item": "minecraft:stick"
 		}
 	},
 	"result": {


### PR DESCRIPTION
The recipes where using forge tags which aren't define in forge. I've replace them by the vanilla item. This means that other mod  items from Forge mods won't be usable for DoT recipes.

This solves 2 bug repports on the Discord & one issue (https://github.com/DawnOfTimeMC/dawnoftimebuilder/issues/56) all about impossible craft in the Fabric version of the mod.

ps: Don't matter about "Paper" in the commit name, I wanted to say "Fabric". 